### PR TITLE
Deeplink playback isssue.

### DIFF
--- a/PluginClasses/HybridScreen/HybridViewController.swift
+++ b/PluginClasses/HybridScreen/HybridViewController.swift
@@ -132,6 +132,12 @@ class HybridViewController: UIViewController {
             self.kalturaPlayerController.showIndicator()
         }
     }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isBeingDismissed {
+          closePlayer()
+        }
+    }
     
     func commonInit() {
         guard let playable = self.playable else {


### PR DESCRIPTION
when playback is in play State and if user Click any deeplink from external, like watsapp, so content playing in background