### PR TITLE
ZNA-7781 - iOS - Changes to Player Subtitles when not available

### DIFF
--- a/PluginClasses/Helpers/StreamTranslationsHelper.swift
+++ b/PluginClasses/Helpers/StreamTranslationsHelper.swift
@@ -69,7 +69,8 @@ fileprivate class StreamTranslationsHelper {
             audioSelectionView.addGestureRecognizer(UITapGestureRecognizer(closure: { (gesture) in
                 ZEE5PlayerManager.sharedInstance().getAudioLanguage()
             }))
-        } else {
+        }
+        else {
             audioSelectionView.gestureRecognizers?.forEach{ audioSelectionView.removeGestureRecognizer($0) }
         }
     }
@@ -94,14 +95,17 @@ fileprivate class StreamTranslationsHelper {
                 available = "MoviesConsumption_MovieDetails_AvailableInOneLanguage_Text".localized(hashMap: [
                     "count": "\(textTracks.count)"
                 ])
-            } else {
+            }
+            else {
                 available = "MoviesConsumption_MovieDetails_AvailableInMultipleLanguages_Text".localized(hashMap: [
                     "count": "\(textTracks.count)"
                 ])
             }
+            
             textSelectionView.selectedTrackLabel.isHidden = false
         
-        } else {
+        }
+        else {
             available = StylesHelper.localizedText(for: "Consumption_Subtitles_NoSubtitles_Text")
             textSelectionView.selectedTrackLabel.isHidden = true
         }
@@ -114,11 +118,10 @@ fileprivate class StreamTranslationsHelper {
             textSelectionView.addGestureRecognizer(UITapGestureRecognizer(closure: { (gesture) in
                 ZEE5PlayerManager.sharedInstance().showSubtitleActionSheet()
             }))
-        } else {
+        }
+        else {
             textSelectionView.gestureRecognizers?.forEach{ textSelectionView.removeGestureRecognizer($0) }
         }
-        
-        
     }
     
     func fill(view: TranslationTrackSelectionView, _ info: StreamTranslationInfo) {

--- a/PluginClasses/Helpers/StreamTranslationsHelper.swift
+++ b/PluginClasses/Helpers/StreamTranslationsHelper.swift
@@ -65,9 +65,13 @@ fileprivate class StreamTranslationsHelper {
         let info = StreamTranslationInfo(title, selected, available)
         fill(view: audioSelectionView, info)
         
-        audioSelectionView.addGestureRecognizer(UITapGestureRecognizer(closure: { (gesture) in
-            ZEE5PlayerManager.sharedInstance().getAudioLanguage()
-        }))
+        if let audioTracks = audioTracks, audioTracks.count > 0 {
+            audioSelectionView.addGestureRecognizer(UITapGestureRecognizer(closure: { (gesture) in
+                ZEE5PlayerManager.sharedInstance().getAudioLanguage()
+            }))
+        } else {
+            audioSelectionView.gestureRecognizers?.forEach{ audioSelectionView.removeGestureRecognizer($0) }
+        }
     }
     
     func handleTextTracks(textSelectionView: TranslationTrackSelectionView) {
@@ -105,9 +109,16 @@ fileprivate class StreamTranslationsHelper {
         let info = StreamTranslationInfo(title, selected, available)
         fill(view: textSelectionView, info)
         
-        textSelectionView.addGestureRecognizer(UITapGestureRecognizer(closure: { (gesture) in
-            ZEE5PlayerManager.sharedInstance().showSubtitleActionSheet()
-        }))
+        
+        if let textTracks = textTracks, textTracks.count > 0 {
+            textSelectionView.addGestureRecognizer(UITapGestureRecognizer(closure: { (gesture) in
+                ZEE5PlayerManager.sharedInstance().showSubtitleActionSheet()
+            }))
+        } else {
+            textSelectionView.gestureRecognizers?.forEach{ textSelectionView.removeGestureRecognizer($0) }
+        }
+        
+        
     }
     
     func fill(view: TranslationTrackSelectionView, _ info: StreamTranslationInfo) {


### PR DESCRIPTION
Note: Subtitles label and Audio Languages label itself should NOT be clickable.
Only the Values in pink (if present) should be clickable.