### PR TITLE
ZNA-7781 - iOS - Changes to Player Subtitles when not available

### DIFF
--- a/PluginClasses/ZEE5PlayerSDK/PlayerManager/ZEE5PlayerManager.m
+++ b/PluginClasses/ZEE5PlayerSDK/PlayerManager/ZEE5PlayerManager.m
@@ -1776,6 +1776,11 @@ static ContentBuisnessType buisnessType;
 }
 -(void)GetAudioLanguage
 {
+    if (self.audioTracks == nil)
+    {
+        return;
+    }
+    
     self.selectedString = LANGUAGE;
 
     [self prepareCustomMenu];
@@ -1814,6 +1819,11 @@ static ContentBuisnessType buisnessType;
 
 -(void)showSubtitleActionSheet
 {
+    if (self.textTracks == nil)
+    {
+        return;
+    }
+    
     self.selectedString = SUBTITLES;
     [self prepareCustomMenu];
 


### PR DESCRIPTION
Til video gets started do not show any popup allowing to select language or subtitles because the list of languages or subtitles is nil.